### PR TITLE
Fix mobile menu toggle on touch devices

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -65,16 +65,20 @@ const Header = () => {
   // Fechar menu quando toca fora
   useEffect(() => {
     if (!isMenuOpen) return;
-    
-    const handleClickOutside = (e: MouseEvent) => {
+
+    const handleClickOutside = (e: Event) => {
       const target = e.target as HTMLElement;
       if (isMenuOpen && !target.closest('[data-mobile-menu]') && !target.closest('[data-mobile-trigger]')) {
         setIsMenuOpen(false);
       }
     };
-    
+
     document.addEventListener('click', handleClickOutside);
-    return () => document.removeEventListener('click', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
   }, [isMenuOpen]);
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);

--- a/src/components/layout/navigation/MobileMenuTrigger.tsx
+++ b/src/components/layout/navigation/MobileMenuTrigger.tsx
@@ -9,6 +9,7 @@ interface MobileMenuTriggerProps {
 const MobileMenuTrigger = ({ isMenuOpen, onToggle }: MobileMenuTriggerProps) => {
   return (
     <button
+      type="button"
       data-mobile-trigger
       className="md:hidden relative z-[60] p-3 -mr-3 text-foreground rounded-full hover:bg-muted/50 active:bg-muted/80 transition-colors tap-highlight-transparent touch-manipulation"
       onClick={onToggle}


### PR DESCRIPTION
## Summary
- ensure the mobile menu trigger is a `<button>` element
- handle `touchstart` events when closing the mobile menu

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840e692da688333a8fbc4a9fd7f9e4e